### PR TITLE
memory issue fix, ready to merge

### DIFF
--- a/R/STmodel.R
+++ b/R/STmodel.R
@@ -54,7 +54,7 @@ createSTmodel <- function(STdata, LUR=NULL, ST=NULL,
                             random.effect=FALSE),
                           locations=list(coords=c("x","y"), long.lat=NULL,
                             coords.beta=NULL, coords.nu=NULL, others=NULL),
-                          strip=FALSE, scale=FALSE, scale.covars=NULL){
+                          strip=FALSE, scale=FALSE, scale.covars=NULL,,predict=FALSE){
   ##check class belonging
   stCheckClass(STdata, "STdata", name="STdata")
 
@@ -174,7 +174,9 @@ createSTmodel <- function(STdata, LUR=NULL, ST=NULL,
     }
   }
   ##compute distance matrix and nt
+  if (!predict){
   STmodel <- createSTmodelInternalDistance(STmodel)
+  }
   
   ##drop SpatioTemporal, has been replaced by other things
   STmodel$SpatioTemporal <- NULL

--- a/R/STmodel_predict.R
+++ b/R/STmodel_predict.R
@@ -268,7 +268,7 @@ predict.STmodel <- function(object, x, STdata=NULL, Nmax=1000, only.pars=FALSE,
                               cov.beta=object$cov.beta, cov.nu=cov.nu,
                               locations=object$locations.list,
                               scale=!is.null(object$scale.covars),
-                              scale.covars=object$scale.covars)
+                              scale.covars=object$scale.covars,predict=TRUE)
     }else{
       ##STdata is an STmodel object ->
       ##test for consistent covariates and scaling (only equal scaling allowed).


### PR DESCRIPTION
Add a parameter (predict, =FALSE as defalt) in the createSTmodel so that when we do prediction, the cross-distance matrix for unobserved sites won't be calculated. Also modified the predict function so that when casting the unobserved data into a STmodel object, the cross-distance matrix won't be calculated.  